### PR TITLE
add label to EvaluateResult result

### DIFF
--- a/rekcurd_dashboard/apis/api_evaluation.py
+++ b/rekcurd_dashboard/apis/api_evaluation.py
@@ -24,6 +24,7 @@ eval_metrics = eval_info_namespace.model('Evaluation result', {
     'precision': fields.List(fields.Float, required=True, description='precision of evaluation'),
     'recall': fields.List(fields.Float, required=True, description='recall of evaluation'),
     'option': fields.Raw(),
+    'label': fields.Raw(),
     'status': fields.Boolean(required=True),
     'result_id': fields.Integer(required=True, description='ID of evaluation result')
 })
@@ -73,7 +74,6 @@ class ApiEvaluation(Resource):
 
 @eval_info_namespace.route('/<int:application_id>/evaluations/<int:evaluation_id>')
 class ApiEvaluation(Resource):
-
     @eval_info_namespace.marshal_with(success_or_not)
     def delete(self, application_id:int, evaluation_id:int):
         """delete data to be evaluated"""

--- a/test/test_api_evaluation.py
+++ b/test/test_api_evaluation.py
@@ -8,13 +8,14 @@ from io import BytesIO
 from rekcurd_dashboard.models import EvaluationResult, Evaluation, db
 
 default_metrics = {'accuracy': 0.0, 'fvalue': [0.0], 'num': 0,
-                   'option': {}, 'precision': [0.0], 'recall': [0.0]}
+                   'option': {}, 'precision': [0.0], 'recall': [0.0], 'label': ['label']}
 
 
 def patch_stub(func):
     def inner_method(*args, **kwargs):
         mock_stub_obj = Mock()
-        metrics = rekcurd_pb2.EvaluationMetrics(precision=[0.0], recall=[0.0], fvalue=[0.0])
+        metrics = rekcurd_pb2.EvaluationMetrics(precision=[0.0], recall=[0.0], fvalue=[0.0],
+                                                label=[rekcurd_pb2.IO(str=rekcurd_pb2.ArrString(val=['label']))])
         mock_stub_obj.EvaluateModel.return_value = rekcurd_pb2.EvaluateModelResponse(metrics=metrics)
         mock_stub_obj.UploadEvaluationData.return_value = rekcurd_pb2.UploadEvaluationDataResponse(status=1, message='success')
         res = rekcurd_pb2.EvaluationResultResponse(


### PR DESCRIPTION
## What is this PR for?

added label to `EvaluationMetrics` to identify which precision, recall and fvalue correspond to which labels.

## This PR includes
`label` is IO type so I used `__get_value_from_io` to get value

## What type of PR is it?

Feature

## What is the issue?

N/A

## How should this be tested?

`python -m unittest test.test_api_evaluation`