### PR TITLE
Bugfix: allow multiple evaluated services

### DIFF
--- a/rekcurd_dashboard/apis/api_evaluation.py
+++ b/rekcurd_dashboard/apis/api_evaluation.py
@@ -118,7 +118,7 @@ class ApiEvaluate(Resource):
         sobj = Service.query.filter(
             Service.application_id == application_id,
             Service.model_id == model_id,
-            Service.service_level != 'production').one_or_none()
+            Service.service_level != 'production').first()
         if sobj is None:
             raise abort(404, 'The model is not used in any services or used only in production.')
 

--- a/test/test_api_evaluation.py
+++ b/test/test_api_evaluation.py
@@ -141,6 +141,9 @@ class ApiEvaluateTest(BaseTestCase):
         model_id = create_service_obj(aobj.application_id).model_id
         evaluation_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
 
+        # create another service to confirm that the API works with multiple candidates
+        create_service_obj(aobj.application_id, model_id=model_id, service_name='foo', save=True)
+
         response = self.client.post(f'/api/applications/{aobj.application_id}/evaluate',
                                     data={'evaluation_id': evaluation_id, 'model_id': model_id})
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
## What is this PR for?

I found if multiple services have the same model_id and application_id when evaluating the model,
`Multiple rows were found for one_or_none()` error occurs.
So I change it to `first` 

## This PR includes

- allow multiple evaluated services
- fix test

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

`python -m unittest test/test_api_evaluation.py`
