### PR TITLE
[Bugfix]add logger option to db handler for KeyError

### DIFF
--- a/rekcurd_dashboard/console_scripts/__init__.py
+++ b/rekcurd_dashboard/console_scripts/__init__.py
@@ -54,6 +54,8 @@ def create_parser():
     parser_db.add_argument(
         '--settings', required=False, help='settings YAML. See https://github.com/rekcurd/dashboard/blob/master/rekcurd_dashboard/template/settings.yml-tpl')
     parser_db.add_argument(
+        '--logger', required=False, help='Python file of your custom logger. Need to inherit "logger_interface.py". See https://github.com/rekcurd/dashboard/blob/master/rekcurd_dashboard/logger/logger_interface.py')
+    parser_db.add_argument(
         '--db_mode', required=False, help='Dashboard DB mode. One of [sqlite/mysql]. Default "sqlite".')
     parser_db.add_argument(
         '--db_host', required=False, help='Dashboard MySQL host. Necessary if "--db_mode mysql".')


### PR DESCRIPTION
## What is this PR for?

If db_handler does not have `logger` option,  
[args["logger"] here](https://github.com/rekcurd/dashboard/blob/master/rekcurd_dashboard/console_scripts/db_handler.py#L20) causes `KeyError: 'logger'`, so I added it.

## This PR includes

- add logger option to db handler

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

`rekcurd_dashboard db init --settings rekcurd_dashboard/template/settings.yml-tpl`
