### PR TITLE
quit saving evaluate result as file

### DIFF
--- a/rekcurd_dashboard/data_servers/__init__.py
+++ b/rekcurd_dashboard/data_servers/__init__.py
@@ -15,10 +15,6 @@ class DataServer(object):
     Upload/Download files.
     """
 
-    # Suffix for evaluation results
-    __EVALUATE_RESULT = '_eval_res.pkl'
-    __EVALUATE_DETAIL = '_eval_detail.pkl'
-
     def upload_model(
             self, data_server_model: DataServerModel, application_model: ApplicationModel, local_filepath: str) -> str:
         filepath = "{0}/ml-{1:%Y%m%d%H%M%S}.model".format(application_model.application_name, datetime.datetime.utcnow())

--- a/test/apis/test_api_evaluation.py
+++ b/test/apis/test_api_evaluation.py
@@ -93,13 +93,14 @@ class ApiEvaluationResultTest(BaseTestCase):
     def test_get(self):
         evaluation_model = create_eval_model(TEST_APPLICATION_ID, save=True)
         eval_result_model = create_eval_result_model(
-            model_id=TEST_MODEL_ID, evaluation_id=evaluation_model.evaluation_id, save=True)
+            model_id=TEST_MODEL_ID, evaluation_id=evaluation_model.evaluation_id,
+            result=json.dumps(default_metrics), save=True)
         response = self.client.get(
             f'/api/projects/{TEST_PROJECT_ID}/applications/{TEST_APPLICATION_ID}/'
             f'evaluation_results/{eval_result_model.evaluation_result_id}')
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.json['status'], True)
-        self.assertEqual(response.json['metrics'], default_metrics)
+        self.assertEqual(response.json['metrics'], dict(default_metrics, result_id=1))
         details = response.json['details']
         self.assertEqual(len(details), 4)
         self.assertEqual(


### PR DESCRIPTION
## What is this PR for?

dashboard saves evaluation result to db (result column of evaluation_result table),
so not need to save as file

## This PR includes

- use evaluation_result from db, not gRPC response
- remove file suffix (because only 1 file is saved in evaluation)

## What type of PR is it?

fix

## What is the issue?

https://github.com/rekcurd/rekcurd-python/issues/45

## How should this be tested?

python -m unittest test/**/*.py
